### PR TITLE
discovery compatibility with node 4 - Buffer signature

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -26,7 +26,7 @@ function discovery (cb) {
   });
 
   server.bind(5678, function () {
-    const message = Buffer.from('irobotmcs');
+    const message = new Buffer('irobotmcs');
     server.setBroadcast(true);
     server.send(message, 0, message.length, 5678, '255.255.255.255');
   });


### PR DESCRIPTION
With Node v4.2.6, I got the following error using the discovery functionnality:
```
$ node discover.js 
Looking for robots...
/home/boris/node_modules/dorita980/lib/discovery.js:29
    const message = Buffer.from('irobotmcs');
                           ^

TypeError: this is not a typed array.
    at Function.from (native)
    at Socket.<anonymous> (/home/boris/node_modules/dorita980/lib/discovery.js:29:28)
    at Socket.g (events.js:260:16)
    at emitNone (events.js:72:20)
    at Socket.emit (events.js:166:7)
    at startListening (dgram.js:121:10)
    at dgram.js:220:7
    at nextTickCallbackWith3Args (node.js:452:9)
    at process._tickCallback (node.js:358:17)
    at Function.Module.runMain (module.js:444:11)
    at startup (node.js:136:18)
    at node.js:966:3
```
The proposed hack fixes the issue.