### PR TITLE
Add support for Roomba i7/i7+ discovery

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -44,7 +44,7 @@ function getRobotPublicInfo (ip, cb) {
   server.on('message', (msg) => {
     try {
       let parsedMsg = JSON.parse(msg);
-      if (parsedMsg.hostname && parsedMsg.ip && parsedMsg.hostname.split('-')[0] === 'Roomba') {
+      if (parsedMsg.hostname && parsedMsg.ip && ((parsedMsg.hostname.split('-')[0] === 'Roomba') || (parsedMsg.hostname.split('-')[0] === 'iRobot'))) {
         server.close();
         parsedMsg.blid = parsedMsg.hostname.split('-')[1];
         cb(null, parsedMsg);


### PR DESCRIPTION
Adds support for Roomba i7 discovery - this allows users to find the BLID for the robot.