### PR TITLE
expose get-roomba-password script as executable command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,22 +139,19 @@ function init () {
 
 (Needed for Cloud and Local requests)
 
-Download or clone this repo, install it, then run `npm run getpassword`. You need to know your robot IP address (look in your router or scan your LAN network with nmap to find it). Or use the `dorita980.getRobotIP()` method.
+You need to know your robot IP address (look in your router or scan your LAN network with nmap to find it). Or use the `dorita980.getRobotIP()` method.
+
+Install `dorita980` globally via `npm install -g dorita980`. Then run:
 
 ```bash
-$ git clone https://github.com/koalazak/dorita980.git
-$ cd dorita980
-$ npm install
-$ npm run getpassword <robotIP>
+$ get-roomba-password <robotIP>
 ```
 
 Example Output:
 
-```
-$ cd dorita980
-$ npm install
-$ npm run getpassword 192.168.1.103
-> node ./bin/getpassword.js "192.168.1.103"
+```bash
+$ npm install -g dorita980
+$ get-roomba-password 192.168.1.103
 
 Make sure your robot is on the Home Base and powered on. Then press and hold the HOME button on your robot until it plays a series of tones (about 2 seconds). Release the button and your robot will flash WIFI light.
 Then press any key...

--- a/bin/getpassword.js
+++ b/bin/getpassword.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 'use strict';
 
 const request = require('request');
@@ -5,7 +7,7 @@ const tls = require('tls');
 const discovery = require('../lib/discovery');
 
 if (!process.argv[2]) {
-  console.log('Use: npm run getpassword <robot_ip_address> [firmware version]');
+  console.log('Usage: get-roomba-password <robot_ip_address> [firmware version]');
   process.exit();
 }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "dorita980",
   "version": "3.0.13",
   "description": "Unofficial iRobot Roomba 980 library sdk",
+  "bin": {
+    "get-roomba-password": "./bin/getpassword.js"
+  },
   "main": "./index.js",
   "directories": {
     "test": "test"


### PR DESCRIPTION
### Description
This PR allows to use the getpassword script by just installing the package globally (or directly by using `npx`). Requiring the consumer to pull and set up the repository is not necessary any more to run the script.

### Proposed changes:

- add `bin/getpassword.js` to `bin` node in package.json
- update `bin/getpassword.js` script to contain a shebang line (`#!/usr/bin/env node`)
- update Readme.md