### PR TITLE
Update README.md to add docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ $ npm install
 $ npm run getpassword <robotIP>
 ```
 
+or docker run command:
+
+```
+docker run ubuntu apt update \
+   && sudo apt install npm \
+   && sudo npm install -g dorita980 \
+   && get-roomba-password <robotIP>
+```
+
 Example Output:
 
 ```


### PR DESCRIPTION
I didn't want to globally install dorita980, this may be a good option for those of us who have docker installed and just need the BLID and the password for something like Home Assistant: https://www.home-assistant.io/components/roomba/