### PR TITLE
Added support for FW version 3 and Braava m6

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function cloud (username, password, version) {
 
 function local (username, password, ip, version, interval) {
   if (version === 1) return localV1(username, password, ip);
-  return localV2(username, password, ip, interval);
+  return localV2(username, password, ip, interval, version);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -12,9 +12,9 @@ function cloud (username, password, version) {
   return cloudV2(username, password);
 }
 
-function local (username, password, ip, version, interval) {
+function local (username, password, ip, version, interval, model) {
   if (version === 1) return localV1(username, password, ip);
-  return localV2(username, password, ip, interval, version);
+  return localV2(username, password, ip, interval, version, model);
 }
 
 module.exports = {

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -2,15 +2,25 @@
 
 const mqtt = require('mqtt');
 
-var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
+var dorita980 = function localV2 (user, password, host, emitIntervalTime, version) {
   if (!user) throw new Error('robotID is required.');
   if (!password) throw new Error('password is required.');
   if (!host) throw new Error('host is required.');
 
   const posibleCap = ['pose', 'ota', 'multiPass', 'carpetBoost', 'pp', 'binFullDetect', 'langOta', 'maps', 'edge', 'eco', 'svcConf'];
+  const versionProps = {
+    2: ['audio', 'soundVer', 'cleanSchedule', 'uiSwVer', 'navSwVer', 'wifiSwVer', 'mobilityVer', 'bootloaderVer', 'umiVer'],
+    3: ['subModSwVer', 'cleanSchedule2']
+  };
+  const modelProps = {
+    'roomba': ['bin'],
+    'braava': ['detectedPad', 'mopReady', 'padWetness']
+  };
+  version = version || 2;
   emitIntervalTime = emitIntervalTime || 800;
   var robotState = {};
   var cap = null;
+  var model = 'roomba';
   var missionInterval;
 
   const url = 'tls://' + host;
@@ -56,6 +66,9 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
           cap = {};
           cap = Object.assign(cap, robotState.cap);
         }
+        if (robotState.sku && robotState.sku.toLowerCase().startsWith("m6")) {
+          model = 'braava';
+        }
       } catch (e) {}
     }
   });
@@ -80,6 +93,16 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
     for (var p in properties) {
       if (posibleCap.indexOf(properties[p]) > -1 && cap && Object.keys(cap).indexOf(properties[p]) === -1) {
         obj[properties[p]] = undefined; // asking for a non available capability, just set to undefined
+      }
+      for (var ver in versionProps) {
+        if (ver != version && versionProps[ver].indexOf(properties[p]) > -1) {
+          obj[properties[p]] = undefined; // this is a property for a different version of API
+        }
+      }
+      for (var mod in modelProps) {
+        if (mod != model && modelProps[mod].indexOf(properties[p]) > -1) {
+          obj[properties[p]] = undefined; // this is a property for a different model
+        }
       }
       if (!obj.hasOwnProperty(properties[p])) {
         return false;
@@ -113,15 +136,16 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
     getTime: () => waitPreferences(false, ['utctime'], true),
     getBbrun: () => waitPreferences(false, ['bbrun'], true),
     getLangs: () => waitPreferences(false, ['langs'], true),
-    getSys: () => waitPreferences(false, ['bbrstinfo', 'cap', 'sku', 'batteryType', 'soundVer', 'uiSwVer', 'navSwVer', 'wifiSwVer', 'mobilityVer', 'bootloaderVer', 'umiVer', 'softwareVer', 'audio', 'bin'], true),
+    getSys: () => waitPreferences(false, ['bbrstinfo', 'cap', 'sku', 'batteryType', 'soundVer', 'uiSwVer', 'navSwVer', 'wifiSwVer', 'mobilityVer', 'bootloaderVer', 'umiVer', 'softwareVer', 'audio', 'bin', 'subModSwVer', 'secureBoot', 'detectedPad'], true),
     getWirelessLastStatus: () => waitPreferences(false, ['wifistat', 'wlcfg'], true),
-    getWeek: () => waitPreferences(false, ['cleanSchedule'], true),
-    getPreferences: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'cleanSchedule', 'name', 'vacHigh', 'signal'], false),
+    getWeek: () => waitPreferences(false, ['cleanSchedule', 'cleanSchedule2'], true),
+    getPreferences: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'cleanSchedule', 'cleanSchedule2', 'name', 'vacHigh', 'signal'], false),
     getRobotState: (fields) => waitPreferences(false, fields, false),
-    getMission: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'pose', 'bin', 'batPct'], true),
-    getBasicMission: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'bin', 'batPct'], true),
+    getMission: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'pose', 'bin', 'batPct', 'detectedPad', 'mopReady', 'padWetness'], true),
+    getBasicMission: (decode) => waitPreferences(decode, ['cleanMissionStatus', 'bin', 'batPct', 'detectedPad', 'mopReady', 'padWetness'], true),
     getWirelessConfig: () => waitPreferences(false, ['wlcfg', 'netinfo'], true),
     getWirelessStatus: () => waitPreferences(false, ['wifistat', 'netinfo'], true),
+    getModel: () => new Promise((resolve) => resolve(model)),
     getCloudConfig: () => waitPreferences(false, ['cloudEnv'], true),
     getSKU: () => waitPreferences(false, ['sku'], true),
     start: () => _apiCall('cmd', 'start'),

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -55,11 +55,16 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
     clearInterval(missionInterval);
   });
 
+  const defaultPose = { "theta":0, "point": { "x": 0, "y": 0 } };
+
   client.on('packetreceive', function (packet) {
     if (packet.payload) {
       try {
         const msg = JSON.parse(packet.payload.toString());
         robotState = Object.assign(robotState, msg.state.reported);
+	if (!robotState.pose) {
+	  robotState.pose = defaultPose;
+	}
         client.emit('update', msg);
         client.emit('state', robotState);
         if (robotState.cap) {

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -2,7 +2,7 @@
 
 const mqtt = require('mqtt');
 
-var dorita980 = function localV2 (user, password, host, emitIntervalTime, version) {
+var dorita980 = function localV2 (user, password, host, emitIntervalTime, version, model) {
   if (!user) throw new Error('robotID is required.');
   if (!password) throw new Error('password is required.');
   if (!host) throw new Error('host is required.');
@@ -20,7 +20,6 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
   emitIntervalTime = emitIntervalTime || 800;
   var robotState = {};
   var cap = null;
-  var model = 'roomba';
   var missionInterval;
 
   const url = 'tls://' + host;
@@ -71,8 +70,12 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
           cap = {};
           cap = Object.assign(cap, robotState.cap);
         }
-        if (robotState.sku && robotState.sku.toLowerCase().startsWith('m6')) {
-          model = 'braava';
+        if (!model && robotState.sku) {
+          if (robotState.sku.toLowerCase().startsWith('m6')) {
+            model = 'braava';
+          } else {
+            model = 'roomba';
+          }
         }
       } catch (e) {}
     }

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -66,7 +66,7 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
           cap = {};
           cap = Object.assign(cap, robotState.cap);
         }
-        if (robotState.sku && robotState.sku.toLowerCase().startsWith("m6")) {
+        if (robotState.sku && robotState.sku.toLowerCase().startsWith('m6')) {
           model = 'braava';
         }
       } catch (e) {}
@@ -95,12 +95,12 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
         obj[properties[p]] = undefined; // asking for a non available capability, just set to undefined
       }
       for (var ver in versionProps) {
-        if (ver != version && versionProps[ver].indexOf(properties[p]) > -1) {
+        if (ver !== version && versionProps[ver].indexOf(properties[p]) > -1) {
           obj[properties[p]] = undefined; // this is a property for a different version of API
         }
       }
       for (var mod in modelProps) {
-        if (mod != model && modelProps[mod].indexOf(properties[p]) > -1) {
+        if (mod !== model && modelProps[mod].indexOf(properties[p]) > -1) {
           obj[properties[p]] = undefined; // this is a property for a different model
         }
       }

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -55,16 +55,16 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime, versio
     clearInterval(missionInterval);
   });
 
-  const defaultPose = { "theta":0, "point": { "x": 0, "y": 0 } };
+  const defaultPose = { 'theta': 0, 'point': { 'x': 0, 'y': 0 } };
 
   client.on('packetreceive', function (packet) {
     if (packet.payload) {
       try {
         const msg = JSON.parse(packet.payload.toString());
         robotState = Object.assign(robotState, msg.state.reported);
-	if (!robotState.pose) {
-	  robotState.pose = defaultPose;
-	}
+        if (!robotState.pose) {
+          robotState.pose = defaultPose;
+        }
         client.emit('update', msg);
         client.emit('state', robotState);
         if (robotState.cap) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dorita980",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "description": "Unofficial iRobot Roomba 980 and wifi other enabled series library sdk",
   "main": "./index.js",
   "directories": {
@@ -39,6 +39,7 @@
     "unofficial",
     "iRobot",
     "Roomba",
+    "Braava",
     "980",
     "wifi",
     "i7",
@@ -46,6 +47,7 @@
     "960",
     "690",
     "675",
+    "m6",
     "library",
     "sdk",
     "robot",


### PR DESCRIPTION
I got Roomba i7 and Braava m6, both with firmware 3.2. I needed to do some changes to support FW version 3, and also to support Braava robots. I'm not sure I captured all the differences between v2 and v3, and between roomba and braava robots. But I think this could be a good start.

This might also be a solution for https://github.com/koalazak/rest980/issues/44 .