### PR TITLE
Update MQTT Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/koalazak/dorita980#readme",
   "dependencies": {
-    "mqtt": "^2.15.0",
+    "mqtt": "^4.3.4,
     "request": "^2.74.0",
     "request-promise": "^4.1.1"
   }


### PR DESCRIPTION
Update to support the latest version of MQTT. The older version is causing some conflicts with homebridge and later versions of node. Requesting this change to support downstream services, specifically homebridge-roomba2.