### PR TITLE
Node18 tls fix

### DIFF
--- a/bin/getpassword.js
+++ b/bin/getpassword.js
@@ -5,6 +5,7 @@
 const request = require('request');
 const tls = require('tls');
 const discovery = require('../lib/discovery');
+const { constants } = require('crypto')
 
 if (!process.argv[2]) {
   console.log('Usage: npm run getpassword <robot_ip_address> [firmware version]');
@@ -88,7 +89,7 @@ function checkV2 () {
     console.log(robotData);
   });
   const packet = 'f005efcc3b2900';
-  var client = tls.connect(8883, host, {timeout: 10000, rejectUnauthorized: false, ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256'}, function () {
+  var client = tls.connect(8883, host, {timeout: 10000, rejectUnauthorized: false, ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256', secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT}, function () {
     client.write(new Buffer(packet, 'hex'));
   });
 

--- a/bin/getpassword.js
+++ b/bin/getpassword.js
@@ -5,7 +5,7 @@
 const request = require('request');
 const tls = require('tls');
 const discovery = require('../lib/discovery');
-const { constants } = require('crypto')
+const { constants } = require('crypto');
 
 if (!process.argv[2]) {
   console.log('Usage: npm run getpassword <robot_ip_address> [firmware version]');

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const mqtt = require('mqtt');
+const { constants } = require('crypto');
 
 var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
   if (!user) throw new Error('robotID is required.');
@@ -24,7 +25,8 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
     ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256',
     clean: false,
     username: user,
-    password: password
+    password: password,
+    secureOptions: constants.SSL_OP_LEGACY_SERVER_CONNECT,
   };
 
   const client = mqtt.connect(url, options);

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "homepage": "https://github.com/koalazak/dorita980#readme",
   "dependencies": {
-    "mqtt": "^2.15.0",
+    "mqtt": "^4.3.7",
     "request": "^2.74.0",
     "request-promise": "^4.1.1"
   }


### PR DESCRIPTION
The TLS connection to Roomba is broken on Node 18 as Roomba doesn't appear to support Secure Renegotiation.

The TLS connection in `mqtt` fails with the error:

```
Error: write EPROTO 002511FF01000000:error:0A000152:SSL routines:final_renegotiate:unsafe legacy renegotiation disabled:../deps/openssl/openssl/ssl/statem/extensions.c:922:
```

When we enable legacy server connect, we are able to successfully connect. See https://www.openssl.org/docs/man1.1.1/man3/SSL_clear_options.html for more information(search for SSL_OP_LEGACY_SERVER_CONNECT).

