### PR TITLE
Add ciphers to support J7

### DIFF
--- a/bin/getpassword.js
+++ b/bin/getpassword.js
@@ -88,7 +88,7 @@ function checkV2 () {
     console.log(robotData);
   });
   const packet = 'f005efcc3b2900';
-  var client = tls.connect(8883, host, {timeout: 10000, rejectUnauthorized: false, ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256'}, function () {
+  var client = tls.connect(8883, host, {timeout: 10000, rejectUnauthorized: false, ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256,TLS_AES_256_GCM_SHA384' }, function () {
     client.write(new Buffer(packet, 'hex'));
   });
 

--- a/lib/v2/local.js
+++ b/lib/v2/local.js
@@ -21,7 +21,7 @@ var dorita980 = function localV2 (user, password, host, emitIntervalTime) {
     rejectUnauthorized: false,
     protocolId: 'MQTT',
     protocolVersion: 4,
-    ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256',
+    ciphers: process.env.ROBOT_CIPHERS || 'AES128-SHA256,TLS_AES_256_GCM_SHA384',
     clean: false,
     username: user,
     password: password


### PR DESCRIPTION
The J7 Roomba appears to require different TLS ciphers to be used. Ciphers is a comma-separated list so we can simply add it and support both ciphers.